### PR TITLE
Updated some QE related tasks to be compatible with QE v6.2 and later.

### DIFF
--- a/BGWpy/DFT/dfttask.py
+++ b/BGWpy/DFT/dfttask.py
@@ -41,6 +41,11 @@ class DFTTask(MPITask):
         self.pseudos    = kwargs.get('pseudos', [])
         self.structure  = kwargs.get('structure')
 
+        # Patches for newer verisons of qe. Originally bgwpy was written for
+        # QE v5 but currently defaults to QE v6.
+        if self.is_flavor_QE:
+            self.version = kwargs.pop('version',  6)
+
         # This task is not part of a workflow.
         # It is executed on-the-fly and leaves no trace (clean_after=True). 
         self.kgridtask = KgridTask(dirname=dirname, **kwargs)

--- a/BGWpy/QE/scftask.py
+++ b/BGWpy/QE/scftask.py
@@ -105,5 +105,10 @@ class QeScfTask(QeTask):
 
     @property
     def data_file_fname(self):
-        return os.path.join(self.dirname, self.savedir, 'data-file.xml')
+        # It seems newer versions of QE have switched from data-file.xml to
+        # data-file-schema.xml
+        if self.version >= 6:
+            return os.path.join(self.dirname, self.savedir, 'data-file-schema.xml')
+        else:
+            return os.path.join(self.dirname, self.savedir, 'data-file.xml')
 

--- a/BGWpy/QE/wfntask.py
+++ b/BGWpy/QE/wfntask.py
@@ -129,7 +129,10 @@ class QeWfnTask(QeTask):
     @data_file_fname.setter
     def data_file_fname(self, value):
         self._data_file_fname = value
-        dest = os.path.join(self.savedir, 'data-file.xml')
+        if self.version >= 6:
+            dest = os.path.join(self.savedir, 'data-file-schema.xml')
+        else:
+            dest = os.path.join(self.savedir, 'data-file.xml')
         self.update_copy(value, dest)
 
     def add_pseudos_copy(self):


### PR DESCRIPTION
This is a first (very small) pull request for BGWpy, mostly to make sure I have the pull request workflow down.

As of QE v6.2, the data-file.xml has been replaced with data-file-schema.xml. I have updated dfttask.py, so users can specify the version of QE they are using. If the version is 6.2 or later, BGWpy links data-file-schema.xml, if earlier than v6.2, BGWpy continues to link data-file.xml. Default is v6.2.