### PR TITLE
Update hdf5 compatibility and minor changes

### DIFF
--- a/BGWpy/BGW/epsilontask.py
+++ b/BGWpy/BGW/epsilontask.py
@@ -76,7 +76,12 @@ class EpsilonTask(BGWTask):
             if key in kwargs:
                 kgrid_kwargs[key] = kwargs[key]
         self.kgridtask = KgridTask(dirname=dirname, **kgrid_kwargs)
-        kpts_ush, wtks_ush = self.kgridtask.get_kpoints()
+
+        symkpt = kwargs.get('symkpt', True)
+        if symkpt:
+            kpts_ush, wtks_ush = self.kgridtask.get_kpoints()
+        else:
+            kpts_ush, wtks_ush = self.kgridtask.get_kpt_grid_nosym()
 
         extra_lines = kwargs.get('extra_lines',[])
         extra_variables = kwargs.get('extra_variables',{})

--- a/BGWpy/BGW/sigmatask.py
+++ b/BGWpy/BGW/sigmatask.py
@@ -98,7 +98,12 @@ class SigmaTask(BGWTask):
                 if key in kwargs:
                     kgrid_kwargs[key] = kwargs[key]
             self.kgridtask = KgridTask(dirname=dirname, **kgrid_kwargs)
-            kpts, wtks = self.kgridtask.get_kpoints()
+
+            symkpt = kwargs.get('symkpt', True)
+            if symkpt:
+                kpts, wtks = self.kgridtask.get_kpoints()
+            else:
+                kpts, wtks = self.kgridtask.get_kpt_grid_nosym()
 
 
         # Use specified qpoints or compute them from grid (HF).

--- a/BGWpy/QE/pwscfinput.py
+++ b/BGWpy/QE/pwscfinput.py
@@ -172,7 +172,8 @@ class PWscfInput(Writable):
             self.cell_parameters.append(np.round(vec, 8))
 
         # Set atomic species
-        for element in structure.types_of_specie:
+        types_of_specie = sorted(set(structure.species), key=structure.species.index)
+        for element in types_of_specie:
             self.atomic_species.append([element.symbol, float(element.atomic_mass)])
 
         if self.pseudos:

--- a/BGWpy/QE/qebgwtask.py
+++ b/BGWpy/QE/qebgwtask.py
@@ -214,7 +214,7 @@ class Qe2BgwTask(QeTask):
 
         # Run script
         self.runscript['PW2BGW'] = 'pw2bgw.x'
-        self.runscript.append('$MPIRUN $PW2BGW -in {} &> {}'.format(
+        self.runscript.append('$MPIRUN $PW2BGW $PWFLAGS -in {} &> {}'.format(
                               self._input_fname, self._output_fname))
 
     _wfn_fname = 'wfn.cplx'

--- a/BGWpy/QE/qetask.py
+++ b/BGWpy/QE/qetask.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import os
 
-from ..config import use_hdf5
+from ..config import use_hdf5, use_hdf5_qe
 from ..core.util import exec_from_dir
 from ..core import MPITask, IOTask
 from ..DFT import DFTTask
@@ -15,7 +15,7 @@ class QeTask(DFTTask, IOTask):
     """Base class for Quantum Espresso calculations."""
 
     _TAG_JOB_COMPLETED = 'JOB DONE'
-    _use_hdf5 = use_hdf5
+    _use_hdf5_qe = use_hdf5_qe
 
     def __init__(self, dirname, **kwargs):
         """

--- a/BGWpy/QE/scftask.py
+++ b/BGWpy/QE/scftask.py
@@ -98,7 +98,7 @@ class QeScfTask(QeTask):
 
     @property
     def charge_density_fname(self):
-        name = 'charge-density.hdf5' if self._use_hdf5 else 'charge-density.dat'
+        name = 'charge-density.hdf5' if self._use_hdf5_qe else 'charge-density.dat'
         return os.path.join(self.dirname, self.savedir, name)
 
     @property

--- a/BGWpy/QE/wfntask.py
+++ b/BGWpy/QE/wfntask.py
@@ -110,7 +110,7 @@ class QeWfnTask(QeTask):
     @charge_density_fname.setter
     def charge_density_fname(self, value):
         self._charge_density_fname = value
-        name = 'charge-density.hdf5' if self._use_hdf5 else 'charge-density.dat'
+        name = 'charge-density.hdf5' if self._use_hdf5_qe else 'charge-density.dat'
         dest = os.path.join(self.savedir, name)
         self.update_link(value, dest)
 

--- a/BGWpy/config/__init__.py
+++ b/BGWpy/config/__init__.py
@@ -3,6 +3,7 @@ from .default_configuration import (
     default_mpi,
     default_runscript,
     use_hdf5,
+    use_hdf5_qe,
     flavor_complex,
     dft_flavor,
     )
@@ -22,6 +23,9 @@ try:
 
         if 'use_hdf5' in dir(user_configuration):
             use_hdf5 = user_configuration.use_hdf5
+
+        if 'use_hdf5_qe' in dir(user_configuration):
+            use_hdf5_qe = user_configuration.use_hdf5_qe
 
         if 'flavor_complex' in dir(user_configuration):
             flavor_complex = user_configuration.flavor_complex

--- a/BGWpy/config/default_configuration.py
+++ b/BGWpy/config/default_configuration.py
@@ -19,6 +19,7 @@ default_runscript = dict(
     )
 
 use_hdf5 = True
+use_hdf5_qe = False
 flavor_complex = True
 
 dft_flavor = 'espresso'

--- a/BGWpy/flows/bseflow.py
+++ b/BGWpy/flows/bseflow.py
@@ -233,7 +233,7 @@ class BSEFlow(Workflow):
         else:
 
             self.scftask = QeScfTask(
-                dirname = pjoin(self.dirname, '01-Density'),
+                dirname = pjoin(self.dirname, '01-density'),
                 ngkpt = self.ngkpt,
                 kshift = self.kshift,
                 **kwargs)
@@ -253,19 +253,21 @@ class BSEFlow(Workflow):
         
         # Wavefunction tasks for Epsilon
         self.wfntask_ksh = QeBgwFlow(
-            dirname = pjoin(self.dirname, '02-Wfn'),
+            dirname = pjoin(self.dirname, '02-wfn'),
             ngkpt = self.ngkpt,
             kshift = self.kshift,
             nbnd = self.nbnd,
             rhog_flag = True,
+            symkpt=False,
             **kwargs)
 
         self.wfntask_qsh = QeBgwFlow(
-            dirname = pjoin(self.dirname, '03-Wfnq'),
+            dirname = pjoin(self.dirname, '03-wfnq'),
             ngkpt = self.ngkpt,
             kshift = self.kshift,
             qshift = self.qshift,
             nbnd = None,
+            symkpt=False,
             **kwargs)
 
         self.add_tasks([self.wfntask_ksh, self.wfntask_qsh])
@@ -275,10 +277,11 @@ class BSEFlow(Workflow):
         if self.has_kshift:
 
             self.wfntask_ush = QeBgwFlow(
-                dirname = pjoin(self.dirname, '04-Wfn_co'),
+                dirname = pjoin(self.dirname, '04-wfn_co'),
                 ngkpt = self.ngkpt,
                 nbnd = self.nbnd,
                 rhog_flag = True,
+                symkpt=False,
                 **kwargs)
 
             self.add_task(self.wfntask_ush)
@@ -288,7 +291,7 @@ class BSEFlow(Workflow):
 
         # Wavefunctions on fine k-point grids
         self.wfntask_fi_ush = QeBgwFlow(
-            dirname = pjoin(self.dirname, '05-Wfn_fi'),
+            dirname = pjoin(self.dirname, '05-wfn_fi'),
             nbnd = self.nbnd_fine,
             ngkpt = self.ngkpt_fi,
             kshift = self.kshift_fi,
@@ -297,7 +300,7 @@ class BSEFlow(Workflow):
             **kwargs)
         
         self.wfntask_fi_qsh = QeBgwFlow(
-            dirname = pjoin(self.dirname, '06-Wfnq_fi'),
+            dirname = pjoin(self.dirname, '06-wfnq_fi'),
             ngkpt = self.ngkpt_fi,
             kshift = self.kshift_fi,
             qshift = self.qshift_fi,
@@ -330,7 +333,7 @@ class BSEFlow(Workflow):
 
         else:
             self.scftask = AbinitScfTask(
-                dirname = pjoin(self.dirname, '01-Density'),
+                dirname = pjoin(self.dirname, '01-density'),
                 ngkpt = self.ngkpt,
                 kshift = self.kshift,
                 **kwargs)
@@ -343,7 +346,7 @@ class BSEFlow(Workflow):
 
         # Wavefunction tasks for Epsilon
         self.wfntask_ksh = AbinitBgwFlow(
-            dirname = pjoin(self.dirname, '02-Wfn'),
+            dirname = pjoin(self.dirname, '02-wfn'),
             ngkpt = self.ngkpt,
             kshift = self.kshift,
             nband = self.nbnd,
@@ -351,7 +354,7 @@ class BSEFlow(Workflow):
             **kwargs)
         
         self.wfntask_qsh = AbinitBgwFlow(
-            dirname = pjoin(self.dirname, '03-Wfnq'),
+            dirname = pjoin(self.dirname, '03-wfnq'),
             ngkpt = self.ngkpt,
             kshift = self.kshift,
             qshift = self.qshift,
@@ -365,7 +368,7 @@ class BSEFlow(Workflow):
         if self.has_kshift:
 
             self.wfntask_ush = AbinitBgwFlow(
-                dirname = pjoin(self.dirname, '04-Wfn_co'),
+                dirname = pjoin(self.dirname, '04-wfn_co'),
                 ngkpt = self.ngkpt,
                 nband = self.nbnd,
                 rhog_flag = True,
@@ -379,7 +382,7 @@ class BSEFlow(Workflow):
 
         # Wavefunctions on fine k-point grids
         self.wfntask_fi_ush = AbinitBgwFlow(
-            dirname = pjoin(self.dirname, '05-Wfn_fi'),
+            dirname = pjoin(self.dirname, '05-wfn_fi'),
             nband = self.nbnd_fine,
             ngkpt = self.ngkpt_fi,
             kshift = self.kshift_fi,
@@ -388,7 +391,7 @@ class BSEFlow(Workflow):
             **kwargs)
         
         self.wfntask_fi_qsh = AbinitBgwFlow(
-            dirname = pjoin(self.dirname, '06-Wfnq_fi'),
+            dirname = pjoin(self.dirname, '06-wfnq_fi'),
             nband = None,
             ngkpt = self.ngkpt_fi,
             kshift = self.kshift_fi,

--- a/BGWpy/flows/gwflow.py
+++ b/BGWpy/flows/gwflow.py
@@ -188,7 +188,7 @@ class GWFlow(Workflow):
         else:
 
             self.scftask = QeScfTask(
-                dirname = pjoin(self.dirname, '01-Density'),
+                dirname = pjoin(self.dirname, '01-density'),
                 ngkpt = self.ngkpt,
                 kshift = self.kshift,
                 **kwargs)
@@ -202,7 +202,7 @@ class GWFlow(Workflow):
         
         # Wavefunction tasks for Epsilon
         self.wfntask_ksh = QeBgwFlow(
-            dirname = pjoin(self.dirname, '02-Wfn'),
+            dirname = pjoin(self.dirname, '02-wfn'),
             ngkpt = self.ngkpt,
             kshift = self.kshift,
             nbnd = self.nbnd,
@@ -210,7 +210,7 @@ class GWFlow(Workflow):
             **kwargs)
 
         self.wfntask_qsh = QeBgwFlow(
-            dirname = pjoin(self.dirname, '03-Wfnq'),
+            dirname = pjoin(self.dirname, '03-wfnq'),
             ngkpt = self.ngkpt,
             kshift = self.kshift,
             qshift = self.qshift,
@@ -224,7 +224,7 @@ class GWFlow(Workflow):
         if self.has_kshift:
 
             self.wfntask_ush = QeBgwFlow(
-                dirname = pjoin(self.dirname, '04-Wfn_co'),
+                dirname = pjoin(self.dirname, '04-wfn_co'),
                 ngkpt = self.ngkpt,
                 nbnd = self.nbnd,
                 rhog_flag = True,
@@ -257,7 +257,7 @@ class GWFlow(Workflow):
 
         else:
             self.scftask = AbinitScfTask(
-                dirname = pjoin(self.dirname, '01-Density'),
+                dirname = pjoin(self.dirname, '01-density'),
                 ngkpt = self.ngkpt,
                 kshift = self.kshift,
                 **kwargs)
@@ -321,7 +321,7 @@ class GWFlow(Workflow):
 
         # Wavefunction tasks for Epsilon
         self.wfntask_ksh = AbinitBgwFlow(
-            dirname = pjoin(self.dirname, '02-Wfn'),
+            dirname = pjoin(self.dirname, '02-wfn'),
             ngkpt = self.ngkpt,
             kshift = self.kshift,
             nband = nbnd,
@@ -330,7 +330,7 @@ class GWFlow(Workflow):
             **kwargs)
         
         self.wfntask_qsh = AbinitBgwFlow(
-            dirname = pjoin(self.dirname, '03-Wfnq'),
+            dirname = pjoin(self.dirname, '03-wfnq'),
             ngkpt = self.ngkpt,
             kshift = self.kshift,
             qshift = self.qshift,
@@ -343,7 +343,7 @@ class GWFlow(Workflow):
         if self.split_wfn:
             nbdbuf = int(self.nbnd*0.2)  # 20% of bands are in buffer
             self.wfntask_large = AbinitBgwFlow(
-                dirname = pjoin(self.dirname, '02-Wfn-large'),
+                dirname = pjoin(self.dirname, '02-wfn-large'),
                 ngkpt = self.ngkpt,
                 kshift = self.kshift,
                 #qshift = self.qshift,  # GA: I am doubtious about this...
@@ -360,7 +360,7 @@ class GWFlow(Workflow):
         if self.has_kshift:
 
             self.wfntask_ush = AbinitBgwFlow(
-                dirname = pjoin(self.dirname, '04-Wfn_co'),
+                dirname = pjoin(self.dirname, '04-wfn_co'),
                 ngkpt = self.ngkpt,
                 nband = self.nbnd,
                 rhog_flag = True,

--- a/BGWpy/flows/vmtxelflow.py
+++ b/BGWpy/flows/vmtxelflow.py
@@ -76,7 +76,7 @@ class VmtxelFlow(Workflow):
 
         else:
             self.scftask = AbinitScfTask(
-                dirname = pjoin(self.dirname, '01-Density'),
+                dirname = pjoin(self.dirname, '01-density'),
                 ngkpt = self.ngkpt,
                 kshift = self.kshift,
                 **kwargs)
@@ -90,7 +90,7 @@ class VmtxelFlow(Workflow):
 
         # Wavefunctions on fine k-point grids
         self.wfntask_fi_ush = AbinitBgwFlow(
-            dirname = pjoin(self.dirname, '05-Wfn_fi'),
+            dirname = pjoin(self.dirname, '05-wfn_fi'),
             nband = self.nbnd_fine,
             ngkpt = self.ngkpt_fi,
             kshift = self.kshift_fi,
@@ -99,7 +99,7 @@ class VmtxelFlow(Workflow):
             **kwargs)
         
         self.wfntask_fi_qsh = AbinitBgwFlow(
-            dirname = pjoin(self.dirname, '06-Wfnq_fi'),
+            dirname = pjoin(self.dirname, '06-wfnq_fi'),
             nband = None,
             ngkpt = self.ngkpt_fi,
             kshift = self.kshift_fi,

--- a/config/user_configuration.py.template
+++ b/config/user_configuration.py.template
@@ -43,6 +43,7 @@ default_runscript = dict(
 # BerkeleyGW can be compiled with or without HDF5 io.
 # Set this flag accordingly.
 use_hdf5 = True
+use_hdf5_qe = False
 
 # BerkeleyGW can be compiled in complex or real flavor.
 # Set this flag accordingly.


### PR DESCRIPTION
1. Included use_hdf5_qe flag to allow for the possibility of using BGW with hdf5 and qe without.
2. Included symkpt option for sigma and epsilon, in case users want to turn off symmetries, useful for debugging and testing new features.
3. Minor cosmetic changes, like like using lowercase dirnames in GW/BSE flows instead of uppercase for some and lower case for others.

